### PR TITLE
[BUGFIX] Bundle dependencies with lowest PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
 
     - stage: deploy
       if: tag IS present
-      php: 7.1
+      php: 7.0
       before_install: skip
       install: skip
       before_script: skip


### PR DESCRIPTION
We must run this step with the lowest supported PHP version to ensure we don't accidentally ship dependencies for newer PHP versions.