### PR TITLE
add tx_formlog_entries to garbage collect task

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ module.tx_formlog {
 }
 ```
 
+## Log entry cleanup
+
+The _Table garbage collection_ Scheduler task can be set up to automatically delete old form log entries. Select `tx_formlog_entries` as _Table to clean up_ and a suitable value for _Delete entries older than given number of days_, 180 by default.
+
 ## Thanks
 
 Development of this package was proudly sponsored by [TÜV Hessen](https://www.tuev-hessen.de/).

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
     "formlog": "self.version",
     "typo3-ter/formlog": "self.version"
   },
+  "suggest": {
+    "typo3/cms-scheduler": "Allows automatic garbage collection of old form entries."
+  },
   "config": {
     "sort-packages": true,
     "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "typo3-ter/formlog": "self.version"
   },
   "suggest": {
-    "typo3/cms-scheduler": "Allows automatic garbage collection of old form entries."
+    "typo3/cms-scheduler": "Allows automatic deletion of old form log entries."
   },
   "config": {
     "sort-packages": true,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,7 +10,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1490193269] = [
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:form/Resources/Private/Language/Database.xlf'][1519643592] = 'EXT:formlog/Resources/Private/Language/Database.xlf';
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']['EXT:form/Resources/Private/Language/Database.xlf'][1519643592] = 'EXT:formlog/Resources/Private/Language/de.Database.xlf';
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']['TYPO3\\CMS\\Scheduler\\Task\\TableGarbageCollectionTask']['options']['tables']['tx_formlog_entries'] = [
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']['tx_formlog_entries'] = [
     'dateField' => 'tstamp',
     'expirePeriod' => 90,
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,5 +12,5 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']['EXT:form/Resou
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']['tx_formlog_entries'] = [
     'dateField' => 'tstamp',
-    'expirePeriod' => 90,
+    'expirePeriod' => 180,
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,3 +9,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1490193269] = [
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:form/Resources/Private/Language/Database.xlf'][1519643592] = 'EXT:formlog/Resources/Private/Language/Database.xlf';
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']['EXT:form/Resources/Private/Language/Database.xlf'][1519643592] = 'EXT:formlog/Resources/Private/Language/de.Database.xlf';
+
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']['tx_formlog_entries'] = [
+    'dateField' => 'tstamp',
+    'expirePeriod' => 90,
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,7 +10,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1490193269] = [
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:form/Resources/Private/Language/Database.xlf'][1519643592] = 'EXT:formlog/Resources/Private/Language/Database.xlf';
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']['EXT:form/Resources/Private/Language/Database.xlf'][1519643592] = 'EXT:formlog/Resources/Private/Language/de.Database.xlf';
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']['tx_formlog_entries'] = [
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']['TYPO3\\CMS\\Scheduler\\Task\\TableGarbageCollectionTask']['options']['tables']['tx_formlog_entries'] = [
     'dateField' => 'tstamp',
     'expirePeriod' => 90,
 ];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,4 +12,5 @@ parameters:
     - '#Parameter .+ expects .+, Prophecy\\.+\\.+Token given\.#'
     - '#.+ does not accept PHPUnit\\Framework\\MockObject\\MockObject\.#'
     - '#Parameter .+ expects .+, PHPUnit\\Framework\\MockObject\\MockObject given\.#'
+    - '#Class TYPO3\\CMS\\Scheduler\\Task\\TableGarbageCollectionTask not found\.#'
   reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
resolves #11 

However there is a pitfall: if someone has the TableGarbageCollectTask configured with "allTables", then this will potentially remove a lot of data without him knowing.

Also we can debate about the 90 days. Typo3's default value for sys_log is 180 days.

