### PR TITLE
Respect column order in export on TYPO3v9+

### DIFF
--- a/Classes/Mvc/View/Export/AbstractExportView.php
+++ b/Classes/Mvc/View/Export/AbstractExportView.php
@@ -51,7 +51,7 @@ abstract class AbstractExportView extends AbstractView implements ConfigurableVi
      */
     protected function getHeaders()
     {
-        $headers = array_column($this->configuration['columns'], 'label');
+        $headers = array_column($this->getColumns(), 'label');
         $headers = array_map(function ($header) {
 
             return  LocalizationUtility::translate($header, 'Formlog') ?: $header;
@@ -67,7 +67,7 @@ abstract class AbstractExportView extends AbstractView implements ConfigurableVi
      */
     protected function getColumnPaths()
     {
-        $columnPaths = array_column($this->configuration['columns'], 'property');
+        $columnPaths = array_column($this->getColumns(), 'property');
 
         return $columnPaths;
     }
@@ -153,5 +153,21 @@ abstract class AbstractExportView extends AbstractView implements ConfigurableVi
             sprintf('Could not convert value of type "%s" to string', is_object($value) ? get_class($value) : gettype($value)),
             1516617588
         );
+    }
+
+    /**
+     * @throws \InvalidArgumentException if the column configuration is empty
+     */
+    private function getColumns(): array
+    {
+        $columns = $this->configuration['columns'] ?? [];
+
+        if (empty($columns)) {
+            throw new \InvalidArgumentException('Export column configuration is empty', 1516620386);
+        }
+
+        ksort($columns);
+
+        return $columns;
     }
 }

--- a/Classes/Mvc/View/Export/CsvView.php
+++ b/Classes/Mvc/View/Export/CsvView.php
@@ -23,14 +23,9 @@ class CsvView extends AbstractExportView
      * Transform view value to a CSV representation
      *
      * @return string
-     * @throws \InvalidArgumentException if the column configuration is empty
      */
     public function render()
     {
-        if (empty($this->configuration['columns'])) {
-            throw new \InvalidArgumentException('CSV export column configuration is empty', 1516620386);
-        }
-
         $headers = $this->getHeaders();
         $columnPaths = $this->getColumnPaths();
         $filename = $this->getOutputFilename();

--- a/Classes/Mvc/View/Export/XlsxView.php
+++ b/Classes/Mvc/View/Export/XlsxView.php
@@ -24,14 +24,9 @@ class XlsxView extends AbstractExportView
      * Transform view value to a XLSX representation
      *
      * @return string
-     * @throws \InvalidArgumentException if the column configuration is empty
      */
     public function render()
     {
-        if (empty($this->configuration['columns'])) {
-            throw new \InvalidArgumentException('XLSX export column configuration is empty', 1517391761);
-        }
-
         $headers = $this->getHeaders();
         $columnPaths = $this->getColumnPaths();
         $filename = $this->getOutputFilename();

--- a/Tests/Unit/Mvc/View/AbstractExportViewTest.php
+++ b/Tests/Unit/Mvc/View/AbstractExportViewTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types = 1);
+
+namespace Pagemachine\Formlog\Tests\Unit\Mvc\View;
+
+/*
+ * This file is part of the Pagemachine TYPO3 Formlog project.
+ */
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use Pagemachine\Formlog\Mvc\View\Export\AbstractExportView;
+
+/**
+ * Testcase for Pagemachine\Formlog\Mvc\View\Export\AbstractExportView
+ */
+final class AbstractExportViewTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function sortsColumns(): void
+    {
+        $view = new class extends AbstractExportView {
+            public function exposeColumnPaths(): array
+            {
+                return $this->getColumnPaths();
+            }
+
+            public function render()
+            {
+            }
+        };
+
+        $configuration = [
+            'columns' => [
+                99 => [
+                    'property' => 'custom',
+                ],
+                10 => [
+                    'property' => 'uid',
+                ],
+                20 => [
+                    'property' => 'page.title',
+                ],
+            ],
+        ];
+        $view->setConfiguration($configuration);
+
+        $result = $view->exposeColumnPaths();
+        $expected = [
+            'uid',
+            'page.title',
+            'custom',
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
Evidently the column configuration from TypoScript has changed its order
in TYPO3v9+ so make sure to respect the order of columns indicated by
their key.