### PR TITLE
Escape formula characters in CSV export

### DIFF
--- a/Classes/Mvc/View/Export/CsvView.php
+++ b/Classes/Mvc/View/Export/CsvView.php
@@ -7,6 +7,7 @@ namespace Pagemachine\Formlog\Mvc\View\Export;
  * This file is part of the Pagemachine TYPO3 Formlog project.
  */
 
+use League\Csv\EscapeFormula;
 use League\Csv\Writer;
 
 /**
@@ -31,6 +32,7 @@ class CsvView extends AbstractExportView
         $filename = $this->getOutputFilename();
 
         $csv = Writer::createFromString('');
+        $csv->addFormatter(new EscapeFormula());
         $csv->insertOne($headers);
         $csv->insertAll($this->generateRows($this->variables['items'], $columnPaths));
 


### PR DESCRIPTION
This automatically prepends a tabulator to formula characters which
should be easy to strip in automated CSV imports and is barely visible
in Calc/Excel.

See https://typo3.org/security/advisory/typo3-psa-2021-002
And https://csv.thephpleague.com/9.0/interoperability/escape-formula-injection/

Fixes #64