### PR TITLE
Require TYPO3 10.4.11+ for "TYPO3" constant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         "php": "^7.4",
         "league/csv": "^9.1",
         "nimmneun/onesheet": "^1.0",
-        "typo3/cms-backend": "^10.4 || ^11.5",
-        "typo3/cms-core": "^10.4 || ^11.5",
-        "typo3/cms-extbase": "^10.4 || ^11.5",
-        "typo3/cms-fluid": "^10.4 || ^11.5",
-        "typo3/cms-form": "^10.4 || ^11.5",
-        "typo3/cms-frontend": "^10.4 || ^11.5",
+        "typo3/cms-backend": "^10.4.11 || ^11.5",
+        "typo3/cms-core": "^10.4.11 || ^11.5",
+        "typo3/cms-extbase": "^10.4.11 || ^11.5",
+        "typo3/cms-fluid": "^10.4.11 || ^11.5",
+        "typo3/cms-form": "^10.4.11 || ^11.5",
+        "typo3/cms-frontend": "^10.4.11 || ^11.5",
         "typo3fluid/fluid": "^2.3"
     },
     "require-dev": {
@@ -41,7 +41,7 @@
         "sclable/xml-lint": "^0.4.0",
         "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.1",
-        "typo3/cms-scheduler": "^10.4 || ^11.5"
+        "typo3/cms-scheduler": "^10.4.11 || ^11.5"
     },
     "replace": {
         "typo3-ter/formlog": "self.version"


### PR DESCRIPTION
This is the earliest version which introduced this constant.

See https://review.typo3.org/c/Packages/TYPO3.CMS/+/66919