### PR TITLE
Revert "[BUGFIX] Convert empty string into empty json"

### DIFF
--- a/Classes/Domain/Data/JsonData.php
+++ b/Classes/Domain/Data/JsonData.php
@@ -14,10 +14,6 @@ final class JsonData extends \ArrayObject implements TypeInterface
 {
     public function __construct(string $jsonString)
     {
-        // if string is empty, convert it into a valid json
-        if (empty($jsonString)) {
-            $jsonString = '{}';
-        }
         $data = json_decode($jsonString, true, 512, \JSON_THROW_ON_ERROR);
 
         parent::__construct($data);


### PR DESCRIPTION
Reverts pagemachine/typo3-formlog#164

As discussed the original error was intentional to point at erroneous data. In this specific case the `data` column did indeed contain an empty string. This should actually not happen since at least `[]` should be in there if there really was no data logged. If that failed for some reason, that original issue should be fixed.