### PR TITLE
Drop typo3/testing-framework 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "slevomat/coding-standard": "^8.0",
         "squizlabs/php_codesniffer": "^3.1",
         "typo3/cms-scheduler": "^11.5 || ^12.4",
-        "typo3/testing-framework": "^6.0 || ^7.0 || ^8.0"
+        "typo3/testing-framework": "^7.0 || ^8.0"
     },
     "replace": {
         "typo3-ter/formlog": "self.version"


### PR DESCRIPTION
This is not necessary since we do not support TYPO3v10 anymore.