### PR TITLE
Restore finisher icon in form editor

### DIFF
--- a/Configuration/Form/Setup.yaml
+++ b/Configuration/Form/Setup.yaml
@@ -30,5 +30,5 @@ TYPO3:
             LogFormData:
               implementationClassName: Pagemachine\Formlog\Domain\Form\Finishers\LoggerFinisher
               formEditor:
-                iconIdentifier: t3-form-icon-finisher
+                iconIdentifier: form-finisher
                 label: formEditor.elements.Form.editor.finishers.LogFormData.label


### PR DESCRIPTION
Fixes [#186](https://github.com/pagemachine/typo3-formlog/issues/186)