### PR TITLE
Render nested array values

### DIFF
--- a/Classes/Rendering/ValueFormatter.php
+++ b/Classes/Rendering/ValueFormatter.php
@@ -62,36 +62,21 @@ final class ValueFormatter
     private function formatArray(array $value, int $level = 0): string
     {
         $indentation = str_repeat('    ', $level);
-
-        if ($this->hasStringKeys($value)) {
-            $arrayValues = [];
-
-            foreach ($value as $key => $arrayValue) {
-                $separator = ' ';
-
-                if (is_array($arrayValue)) {
-                    $separator = "\n";
-                    $arrayValue = $this->formatArray($arrayValue, $level + 1);
-                }
-
-                $arrayValues[] = sprintf(
-                    '%s%s:%s%s',
-                    $indentation,
-                    $key,
-                    $separator,
-                    $arrayValue
-                );
-            }
-
-            return implode("\n", $arrayValues);
-        }
-
         $arrayValues = [];
 
-        foreach ($value as $arrayValue) {
+        foreach ($value as $key => $arrayValue) {
+            $separator = ' ';
+
+            if (is_array($arrayValue)) {
+                $separator = "\n";
+                $arrayValue = $this->formatArray($arrayValue, $level + 1);
+            }
+
             $arrayValues[] = sprintf(
-                '%s%s',
+                '%s%s:%s%s',
                 $indentation,
+                $key,
+                $separator,
                 $arrayValue
             );
         }
@@ -102,13 +87,5 @@ final class ValueFormatter
     private function formatDateTime(\DateTimeInterface $value): string
     {
         return $value->format($this->dateTimeFormat);
-    }
-
-    /**
-     * @see https://stackoverflow.com/a/4254008/6812729
-     */
-    private function hasStringKeys(array $array): bool
-    {
-        return count(array_filter(array_keys($array), 'is_string')) > 0;
     }
 }

--- a/Tests/Unit/Form/Element/JSONDataElementTest.php
+++ b/Tests/Unit/Form/Element/JSONDataElementTest.php
@@ -74,8 +74,8 @@ HTML;
         $expected = <<<HTML
 <table class="table table-striped table-hover">
 <tr><th>Field</th><th>Value</th></tr>
-<tr><th>foo</th><td style="white-space: pre">bar
-qux</td></tr>
+<tr><th>foo</th><td style="white-space: pre">0: bar
+1: qux</td></tr>
 </table>
 HTML;
         yield 'list of values' => ['{"foo":["bar","qux"]}', $expected];
@@ -85,8 +85,8 @@ HTML;
 <tr><th>Field</th><th>Value</th></tr>
 <tr><th>foo</th><td style="white-space: pre">bar: qux
 list:
-    first
-    second</td></tr>
+    0: first
+    1: second</td></tr>
 </table>
 HTML;
         yield 'nested values' => ['{"foo":{"bar": "qux","list":["first","second"]}}', $expected];

--- a/Tests/Unit/Rendering/ValueFormatterTest.php
+++ b/Tests/Unit/Rendering/ValueFormatterTest.php
@@ -60,9 +60,9 @@ final class ValueFormatterTest extends UnitTestCase
                 'qux',
             ],
             <<<TEXT
-foo
-bar
-qux
+0: foo
+1: bar
+2: qux
 TEXT
 ,
         ];
@@ -99,7 +99,7 @@ TEXT
 ,
         ];
 
-        yield 'mixed array' => [
+        yield 'array with mixed values' => [
             [
                 '1st' => [
                     '2nd' => 'foo',
@@ -115,6 +115,32 @@ TEXT
     3rd:
         4th: bar
     5th: qux
+TEXT
+,
+        ];
+
+        yield 'array with mixed keys' => [
+            [
+                [
+                    '1st' => 'foo',
+                    '2nd' => [],
+                ],
+                [
+                    '1st' => 'bar',
+                    '2nd' => [
+                        '3rd',
+                    ],
+                ],
+            ],
+            <<<TEXT
+0:
+    1st: foo
+    2nd:
+
+1:
+    1st: bar
+    2nd:
+        0: 3rd
 TEXT
 ,
         ];


### PR DESCRIPTION
Such kind of values are produced e.g. by [tritum/repeatable-form-elements](https://packagist.org/packages/tritum/repeatable-form-elements).

| Before | After |
|-|-|
| ![image](https://github.com/pagemachine/typo3-formlog/assets/5037116/8573b7ab-9fca-48c3-9083-4c82c3e80105) | ![image](https://github.com/pagemachine/typo3-formlog/assets/5037116/387bf51f-4bb8-4218-ab56-b8dc97b8a2cb) |

Fixes #191