### PR TITLE
Ensure latest TYPO3v11 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
         php:
           - '8.1'
         typo3:
-          - ^11.5
+          - ^11.5.3
           - ^12.4
         include:
           - php: '8.0'
-            typo3: ^11.5
+            typo3: ^11.5.3
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
For some unknown reason Composer picks TYPO3 11.5.2 for the "^11.5" version constraint instead of really the latest version. This requires further investigation but for now we "help" Composer a bit by raising this to "^11.5.3".