### PR TITLE
Drop docblock type hints

### DIFF
--- a/Classes/Domain/Model/FormLogEntry.php
+++ b/Classes/Domain/Model/FormLogEntry.php
@@ -21,34 +21,16 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  */
 class FormLogEntry extends AbstractEntity
 {
-    /**
-     * @var Page|null
-     */
     public ?Page $page = null;
 
-    /**
-     * @var \DateTime|null
-     */
     public ?\DateTime $submissionDate = null;
 
-    /**
-     * @var int|null
-     */
     public ?int $language = null;
 
-    /**
-     * @var string
-     */
     public string $identifier = '';
 
-    /**
-     * @var JsonData|null
-     */
     public ?JsonData $data = null;
 
-    /**
-     * @var JsonData|null
-     */
     public ?JsonData $finisherVariables = null;
 
     public function getSiteLanguage(): ?SiteLanguage

--- a/Classes/Domain/Model/FormLogEntry/Page.php
+++ b/Classes/Domain/Model/FormLogEntry/Page.php
@@ -15,8 +15,5 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  */
 class Page extends AbstractEntity
 {
-    /**
-     * @var string
-     */
     public string $title = '';
 }


### PR DESCRIPTION
These were kept around for TYPO3v10 Legacy Mode compat but support for TYPO3v10 has been dropped in the mean time.

Basically reverts https://github.com/pagemachine/typo3-formlog/pull/141 again.