### PR TITLE
Drop obsolete variable type hints

### DIFF
--- a/Classes/Controller/Backend/FormLogController.php
+++ b/Classes/Controller/Backend/FormLogController.php
@@ -71,7 +71,6 @@ class FormLogController extends ActionController
     {
         $entries = $this->formLogEntryRepository->findAllFiltered($filters);
         $paginator = new QueryResultPaginator($entries, $currentPageNumber);
-        /** @var UriBuilder */
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
 
         $this->view->assignMultiple([

--- a/Classes/Domain/Form/Finishers/LoggerFinisher.php
+++ b/Classes/Domain/Form/Finishers/LoggerFinisher.php
@@ -78,9 +78,7 @@ class LoggerFinisher extends AbstractFinisher implements LoggerAwareInterface
             'finisher_variables' => $encodedFinisherVariables,
         ];
 
-        /** @var ConnectionPool */
         $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        /** @var \TYPO3\CMS\Core\Database\Connection */
         $connection = $connectionPool->getConnectionForTable('tx_formlog_entries');
         $connection->insert('tx_formlog_entries', $data);
 


### PR DESCRIPTION
These are inferred properly by tools and editors nowadays.