### PR TITLE
Set functional test DB credentials via environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       TYPO3_API_USERNAME:
       TAG:
       typo3DatabaseHost: mysql
+      typo3DatabaseName: typo3
+      typo3DatabaseUsername: root
       typo3DatabasePassword: root
     depends_on:
       mysql:

--- a/phpunit-functional.xml
+++ b/phpunit-functional.xml
@@ -21,12 +21,6 @@
       <directory suffix=".php">Classes/</directory>
     </include>
   </coverage>
-  <php>
-    <env name="typo3DatabaseName" value="typo3_functional"/>
-    <env name="typo3DatabaseHost" value="127.0.0.1"/>
-    <env name="typo3DatabaseUsername" value="root"/>
-    <env name="typo3DatabasePassword" value=""/>
-  </php>
   <testsuites>
     <testsuite name="Functional tests">
       <directory>Tests/Functional/</directory>


### PR DESCRIPTION
The values of these depend on the environment, thus they should be set accordingly. This ensures that environment changes like e.g. a DBMS switch are properly respected.