### PR TITLE
Add legacy module identifier as alias

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -9,6 +9,9 @@ return [
             'after' => 'web_FormFormbuilder',
         ],
         'access' => 'user',
+        'aliases' => [
+            'web_FormlogList',
+        ],
         'labels' => 'LLL:EXT:formlog/Resources/Private/Language/locallang_mod_formlog.xlf',
         'icon' => 'EXT:formlog/Resources/Public/Icons/module-list.svg',
         'inheritNavigationComponentFromMainModule' => false,


### PR DESCRIPTION
This ensures that e.g. BE user group permissions set up on TYPO3v11 will work without change on TYPO3v12.

Notice that this requires at least TYPO3 12.4.16 due to a bugfix.

See https://review.typo3.org/c/Packages/TYPO3.CMS/+/84468