### PR TITLE
[FEATURE] Add option to skip saving composite fields

### DIFF
--- a/Classes/Domain/Form/Finishers/LoggerFinisher.php
+++ b/Classes/Domain/Form/Finishers/LoggerFinisher.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference as ExtbaseFileReference;
 use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
 use TYPO3\CMS\Form\Domain\Finishers\Exception\FinisherException;
+use TYPO3\CMS\Form\Domain\Model\FormElements\FormElementInterface;
 use TYPO3\CMS\Form\Domain\Model\FormElements\StringableFormElementInterface;
 
 /**
@@ -32,6 +33,8 @@ class LoggerFinisher extends AbstractFinisher implements LoggerAwareInterface
      */
     protected $defaultOptions = [
         'finisherVariables' => [],
+        'includeHiddenElements' => true,
+        'skipElementsTypes' => 'ContentElement,StaticText',
     ];
 
     /**
@@ -92,8 +95,33 @@ class LoggerFinisher extends AbstractFinisher implements LoggerAwareInterface
     {
         $normalizedFormValues = [];
         $formDefinition = $this->finisherContext->getFormRuntime()->getFormDefinition();
+        $skipHiddenElements = !$this->parseOption('includeHiddenElements');
+        $skipElementTypes = GeneralUtility::trimExplode(',', $this->parseOption('skipElementsTypes'));
 
         foreach ($this->finisherContext->getFormValues() as $identifier => $formValue) {
+
+            $element = $formDefinition->getElementByIdentifier($identifier);
+            $elementType = null;
+            if ($element !== null) {
+                $renderingOptions = $element->getRenderingOptions();
+                $elementType = $element->getType();
+            }
+            if (
+                $skipHiddenElements &&
+                (
+                    // Mimik the logik of \TYPO3\CMS\Form\Domain\Finishers\EmailFinisher
+                    // with conditions against {formValue.value} and {formValue.isSection} in
+                    // EXT:form/Resources/Private/Frontend/Templates/Finishers/Email/Default.html
+                    // where {formValue.isSection} is set in \TYPO3\CMS\Form\ViewHelpers\RenderFormValueViewHelper::renderStatic()
+                    ($renderingOptions['_isCompositeFormElement'] ?? false)
+                    || ($renderingOptions['_isSection'] ?? false)
+                    // additionally skip configurable element types which don't actually have form values (e.g. StaticText)
+                    || in_array($elementType, $skipElementTypes)
+                )
+            ) {
+                continue;
+            }
+
             if (is_object($formValue)) {
                 if ($formValue instanceof ExtbaseFileReference) {
                     $formValue = $formValue->getOriginalResource();
@@ -107,8 +135,6 @@ class LoggerFinisher extends AbstractFinisher implements LoggerAwareInterface
                     ];
                     continue;
                 }
-
-                $element = $formDefinition->getElementByIdentifier($identifier);
 
                 if ($element instanceof StringableFormElementInterface) {
                     $normalizedFormValues[$identifier] = $element->valueToString($formValue);

--- a/Configuration/Form/Setup.yaml
+++ b/Configuration/Form/Setup.yaml
@@ -22,6 +22,11 @@ TYPO3:
                           identifier: header
                           templateName: Inspector-CollectionElementHeaderEditor
                           label: formEditor.elements.Form.editor.finishers.LogFormData.label
+                        200:
+                          identifier: 'includeHiddenElements'
+                          templateName: 'Inspector-CheckboxEditor'
+                          label: 'formEditor.elements.Form.editor.finishers.LogFormData.includeHiddenElements.label'
+                          propertyPath: 'options.includeHiddenElements'
                         9999:
                           identifier: removeButton
                           templateName: Inspector-RemoveElementEditor
@@ -32,3 +37,7 @@ TYPO3:
               formEditor:
                 iconIdentifier: form-finisher
                 label: formEditor.elements.Form.editor.finishers.LogFormData.label
+                predefinedDefaults:
+                  options:
+                    includeHiddenElements: true
+                    skipElementsTypes: 'ContentElement,StaticText'

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ finishers:
 
 The `LogFormData` finisher should be the last finisher or right before the `Redirect` finisher if used. Logging after a redirect is not possible.
 
+## Configuration
+
+### Save values from hidden or composite Elements
+
+Some form elements, such as fieldsets or other containers, do not hold a form value by themselves; only their child elements hold values. By default, all form elements are saved, even those that never contain values, which can result in empty columns in the log records and exports.
+
+To prevent this, set the finisher option `includeHiddenElements` to `false`. This option ensures that values from composite elements are not saved, similar to how the `EmailFinisher` only includes fields in emails that actually contain a value.
+
+Additionally, you can use the finisher option `skipElementsTypes` to exclude specific form elements (comma separated list). By default, this option excludes `ContentElement` and `StaticText` elements, as they will never have a value.
+
+### Logging of finisher variables
+
 Additional variables stored in the `FinisherVariableProvider` can also be logged by using the `finisherVariables` option:
 
 ```

--- a/Resources/Private/Language/Database.xlf
+++ b/Resources/Private/Language/Database.xlf
@@ -7,7 +7,9 @@
       <trans-unit id="formEditor.elements.Form.editor.finishers.LogFormData.label">
         <source>Log form data</source>
       </trans-unit>
-
+      <trans-unit id="formEditor.elements.Form.editor.finishers.LogFormData.includeHiddenElements.label">
+        <source>Store composite form element data?</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Language/de.Database.xlf
+++ b/Resources/Private/Language/de.Database.xlf
@@ -8,7 +8,10 @@
         <source>Log form data</source>
         <target>Formulardaten loggen</target>
       </trans-unit>
-
+      <trans-unit id="formEditor.elements.Form.editor.finishers.LogFormData.includeHiddenElements.label">
+        <source>Store composite form element data?</source>
+        <target>Formulardaten von Composite-Elementen speichern?</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
intitially based on the PR #33 but taking the review comments into account. It is tested against the latest version of the extension and TYPO3 v12.4

This pull request introduces a feature to control the saving of values from hidden or composite form elements. In current behavior, all form elements are saved by default, even if they do not hold any value, leading to empty columns in log records and exports. This is different to how the core EmailFinisher handles it. 

1. **`includeHiddenElements` Finisher Option:**
   - A new finisher option, `includeHiddenElements`, has been introduced.
   - When set to `false`, this option prevents values from hidden or composite elements from being saved.
   - This behavior is similar  but not the same to the existing `EmailFinisher`, which only includes fields that actually hold a value.
   - can be toggled in the inspector

2. **`skipElementsTypes` Finisher Option:**
   - The new option `skipElementsTypes` allows users to specify which form elements should be excluded from being saved.
   - This is configured as a comma-separated list of element types.
   - By default, this option includes `ContentElement` and `StaticText` elements, as these elements do not hold values.

### Impact:
These changes will help reduce unnecessary data storage and improve the efficiency of data handling in log records and exports. By allowing customization of which elements are saved, users can better manage their form data and avoid clutter from empty values.
