### PR TITLE
Finalize form log entries move to root level

### DIFF
--- a/Classes/Domain/Repository/FormLogEntryRepository.php
+++ b/Classes/Domain/Repository/FormLogEntryRepository.php
@@ -25,17 +25,6 @@ class FormLogEntryRepository extends Repository
     ];
 
     /**
-     * @return QueryInterface
-     */
-    public function createQuery()
-    {
-        $query = parent::createQuery();
-        $query->getQuerySettings()->setRespectStoragePage(false);
-
-        return $query;
-    }
-
-    /**
      * Find all objects optionally filtered
      */
     public function findAllFiltered(Filters $filters): QueryResultInterface

--- a/Configuration/TCA/tx_formlog_entries.php
+++ b/Configuration/TCA/tx_formlog_entries.php
@@ -10,7 +10,7 @@ return [
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
         'delete' => 'deleted',
-        'rootLevel' => -1,
+        'rootLevel' => 1,
         'readOnly' => true,
         'iconfile' => 'EXT:formlog/Resources/Public/Icons/tx_formlog_entries.svg',
     ],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,12 +1,9 @@
 <?php
 
 use Pagemachine\Formlog\Controller\Backend\FormLogController;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die();
-
-ExtensionManagementUtility::allowTableOnStandardPages('tx_formlog_entries');
 
 ExtensionUtility::registerModule(
     'Formlog',


### PR DESCRIPTION
By decoupling the page info in log entries we effectively moved the form log entries to the root level. Due to this the configuration and persistence setup can be simplified now.

See https://github.com/pagemachine/typo3-formlog/pull/235