### PR TITLE
Drop obsolete mysqld command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
 
   mysql:
     image: mysql:8.0
-    command: ['mysqld', '--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
     healthcheck:


### PR DESCRIPTION
MySQL uses UTF8 by default since version 8.