### PR TITLE
Drop obsolete test requirements

### DIFF
--- a/Tests/Unit/Domain/FormLog/DateRangeFilterTest.php
+++ b/Tests/Unit/Domain/FormLog/DateRangeFilterTest.php
@@ -14,8 +14,6 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * Testcase for Pagemachine\Formlog\Domain\FormLog\DateRangeFilter
- *
- * @requires PHP 7
  */
 class DateRangeFilterTest extends UnitTestCase
 {

--- a/Tests/Unit/Domain/FormLog/FiltersTest.php
+++ b/Tests/Unit/Domain/FormLog/FiltersTest.php
@@ -17,8 +17,6 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * Testcase for Pagemachine\Formlog\Domain\FormLog\Filters
- *
- * @requires PHP 7
  */
 class FiltersTest extends UnitTestCase
 {

--- a/Tests/Unit/Domain/FormLog/ValueFilterTest.php
+++ b/Tests/Unit/Domain/FormLog/ValueFilterTest.php
@@ -14,8 +14,6 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * Testcase for Pagemachine\Formlog\Domain\FormLog\ValueFilter
- *
- * @requires PHP 7
  */
 class ValueFilterTest extends UnitTestCase
 {


### PR DESCRIPTION
We use PHP 8.1+ by now.