### PR TITLE
Drop process isolation of functional tests

### DIFF
--- a/phpunit-functional.xml
+++ b/phpunit-functional.xml
@@ -5,7 +5,6 @@
   backupGlobals="true"
   bootstrap="vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
   colors="true"
-  processIsolation="true"
   stopOnError="false"
   stopOnFailure="false"
   stopOnIncomplete="false"


### PR DESCRIPTION
This is not necessary anymore.